### PR TITLE
useShareForwardRef in order to support ref functions.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
-import React, { useEffect, forwardRef, useRef, useLayoutEffect } from "react";
+import React, { useEffect, forwardRef, useLayoutEffect } from "react";
 import { VariableSizeList } from "react-window";
-import Cache from "./cache";
 import debounce from "lodash.debounce";
+
+import useShareForwardedRef from "./utils/useShareForwardRef";
+import Cache from "./cache";
 import measureElement, { destroyMeasureLayer } from "./asyncMeasurer";
 
 /**
@@ -29,8 +31,7 @@ const DynamicList = (
   },
   ref
 ) => {
-  const localRef = useRef();
-  const listRef = ref || localRef;
+  const listRef = useShareForwardedRef(ref);
   const containerResizeDeps = [];
 
   if (recalculateItemsOnResize.width) {

--- a/src/utils/useShareForwardRef.js
+++ b/src/utils/useShareForwardRef.js
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * This hooks allows the component to hold a ref while also exposing the same ref to its parents.
+ * For example:
+ * const MyComponent = (props, ref) => {
+ *   const innerRef = useShareForwardedRef(ref);
+ *
+ *   ...
+ *
+ *   return <div ref={ref}>
+ *    ...
+ *   </div>
+ * }
+ *
+ * https://gist.github.com/pie6k/b4717f392d773a71f67e110b42927fea
+ */
+const useShareForwardedRef = forwardedRef => {
+  // final ref that will share value with forward ref. this is the one we will attach to components
+  const innerRef = useRef(null);
+
+  // after every render - try to share current ref value with forwarded ref
+  useEffect(() => {
+    if (!forwardedRef) {
+      return;
+    }
+    if (typeof forwardedRef === "function") {
+      forwardedRef(innerRef.current);
+    } else {
+      forwardedRef.current = innerRef.current;
+    }
+  });
+
+  return innerRef;
+};
+
+export default useShareForwardedRef;


### PR DESCRIPTION
Allows undefined, ref objects and ref functions as ref parameter.